### PR TITLE
add `here` dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     styler,
     digest,
     piggyback
+    here
 Suggests:
     phytools,
     ggtree,


### PR DESCRIPTION
The method `here::here()` is used in `download_git_release()`, but the `here` package was not set as a dependency.